### PR TITLE
fix: remove default label

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,6 @@ inputs:
   LABELS:
     required: false
     description: Clifus pull request labels
-    default: dependencies
   PUSH_TO_FORK:
     required: false
     description: Repository to push the pull request to


### PR DESCRIPTION
If clifus is run with a non-admin used this settings does not work.

This change fixes the default to make it work with default inputs
without requiring admin right.