### PR TITLE
fix: add `--user` to `pip install`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Install PyYAML
       shell: bash
-      run: pip install PyYAML
+      run: pip install --user PyYAML
 
     - name: Run Clifus
       shell: bash


### PR DESCRIPTION
Otherwise we get this error, which might be because of GitHub's Ubuntu images changes:
```
Run pip install PyYAML
  pip install PyYAML
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.12/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
Error: Process completed with exit code 1.
```