### PR TITLE
fix: don't put venv in current directory

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,11 @@ runs:
     - name: Setup python and run Clifus
       id: clifus
       shell: bash
+      env:
+        TMPDIR: ${{ runner.temp }}
       run: |
-        python3 -m venv .venv
-        source .venv/bin/activate
+        python3 -m venv $TMPDIR/.venv
+        source $TMPDIR.venv/bin/activate
         python3 -m pip install -r ${{ github.action_path }}/requirements.txt
 
         python ${{ github.action_path }}/clifus.py -c "${{ inputs.CLIFUS_CONFIGURATION }}" -s "${{ inputs.SOURCE }}" > output.txt


### PR DESCRIPTION
GHA Workflow usually create a PR after we change the source code.

The .venv is currently committed in the PR.

This will avoid this.